### PR TITLE
Switch out "Server" for "Salesforce"

### DIFF
--- a/suds/__init__.py
+++ b/suds/__init__.py
@@ -59,14 +59,14 @@ class BuildError(Exception):
 class WebFault(Exception):
     def __init__(self, fault, document):
         if hasattr(fault, "faultstring"):
-            Exception.__init__(self, u"Server raised fault: '%s'" %
+            Exception.__init__(self, u"Salesforce raised fault: '%s'" %
                 (fault.faultstring,))
         self.fault = fault
         self.document = document
 
 class HttpWebFault(WebFault):
     def __init__(self, code, reason):
-        Exception.__init__(self, u"Server returned HTTP error [%s]: '%s'" % (code, reason))
+        Exception.__init__(self, u"Salesforce returned HTTP error [%s]: '%s'" % (code, reason))
         self.status_code = code
         self.fault = reason
 


### PR DESCRIPTION
As we maintain this library for talking to Salesforce SOAP API, let's
replace all mention of "Server" with "Salesforce" for convenience and
clarity.

---

This is the equivalent of the change in sf-suds but in the library we actually use.
