### PR TITLE
Remove `normalize_path` import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -460,7 +460,7 @@ if test_error:
 
 
 else:
-    from setuptools.command.test import normalize_path as _normalize_path, test as _test
+    from setuptools.command.test import test as _test
 
     class TestCommand(_test):
         # Derived from setuptools.command.test.test for its


### PR DESCRIPTION
## Rationale
`normalize_path` was imported, but not used, and is no longer available.

## Links
- Slack Thread: https://salesforce-internal.slack.com/archives/C775UTWTF/p1740696868228279
- Slack Thread: https://salesforce-internal.slack.com/archives/C028X3QM3AT/p1742494728207049